### PR TITLE
Fix PreferenceManager initialization

### DIFF
--- a/lib/utils/const_preference/preference.dart
+++ b/lib/utils/const_preference/preference.dart
@@ -1,9 +1,11 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
 class PreferenceManager {
-  static SharedPreferences _preferences = _preferences;
+  static late SharedPreferences _preferences;
 
-  static Future init() async => _preferences = await SharedPreferences.getInstance();
+  static Future<void> init() async {
+    _preferences = await SharedPreferences.getInstance();
+  }
 
   static Future setString(String key, String value) async => await _preferences.setString(key, value);
 


### PR DESCRIPTION
## Summary
- correct `PreferenceManager` initialization

## Testing
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845193adaac832dabe210974c9439e9